### PR TITLE
Fix: [fix/#140/button_type] Add button type in Button component

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -40,6 +40,7 @@ export default function Button({
 
   return (
     <button
+      type={'button'}
       className={twMerge(`${buttonSize[size]} ${style[type]}`, className)}
       onClick={handleClick}
       {...props}


### PR DESCRIPTION
## 🏋🏻 Changes
- [x] Button type 지정하였습니다.

## 🎒 Background
Button type을 지정하지 않아, form 태그 내에서 자동으로 submit type으로 지정되어 처리되는 현상을 수정하기 위해 Button component내의 type을 지정하였습니다.

<br>
✅ closes #140 
