### PR TITLE
Fix: [fix/#163/env_error] Fix 'env' not present on type 'ImportMeta'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "useDefineForClassFields": true,
     "strict": true,
     "skipLibCheck": true,
-    "typeRoots": ["types"]
+    "typeRoots": ["types"],
+    "types": ["vite/client"]
   }
 }


### PR DESCRIPTION
## 🏋🏻 Changes
- [x] 'env'속성이 'ImportMeta' 유형에 존재하지 않는다는 문제 해결

## 🎒 Background
해결 완료

<br>
✅ closes #163 
